### PR TITLE
Add pipeline to code maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,10 @@ from [awesome-erlang](https://github.com/drobakowski/awesome-erlang).
 
     </details>
 
+  - <details><summary><b><a href="https://github.com/choptastic/pipeline">pipeline</a></b>: A parse transform to add a pipe mechanism to Erlang function composition (think Elixir's `|>` operator)</summary>
+
+    </details>
+
 ## CMS
 
 *Erlang powered Content Management System (CMS)*
@@ -975,6 +979,7 @@ longitudes.*
   - <details><summary><b><a href="https://github.com/ferd/erlang-history">erlang-history</a></b>: Hacks to add shell history to Erlang's shell.</summary>
 
     </details>
+  
 
   - <details><summary><b><a href="https://github.com/ShoreTel-Inc/erld">erld</a></b>:  erld is a small program designed to solve the problem of running Erlang programs as a UNIX daemon.</summary>
 


### PR DESCRIPTION
This adds https://github.com/choptastic/pipeline, which is the official fork of https://github.com/stolen/pipeline

But I wonder if there might be a need for a different category, say for metaprogramming, parse transforms, or something of that nature?