### PR TITLE
Add rekt to Code Maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,10 @@ from [awesome-erlang](https://github.com/drobakowski/awesome-erlang).
     Reviewer.</summary>
 
     </details>
+ 
+  - <details><summary><b><a href="https://github.com/nitrogen/rekt">rekt</a></b>: A parse transform to define new Erlang records from existing records, similar to inheritance in objected oriented languages.</summary>
+
+    </details>
 
 ## CMS
 


### PR DESCRIPTION
Adds https://github.com/nitrogen/rekt

(not sure if this belongs in this section, but it *can* help with keeping a cleaner codebase, at least if you do a lot with many record definitions)

Thanks!