### PR TITLE
Add erli18n (Translations and Internationalizations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1817,6 +1817,11 @@ techniques.*
 
 *Libraries providing translations or internationalizations.*
 
+  - <details><summary><b><a href="https://github.com/eagle-head/erli18n">erli18n</a></b>: GNU gettext-compatible internationalization (i18n) library for Erlang/OTP, in pure Erlang.</summary>
+
+    <br/>
+    </details>
+
 
 ## Web Frameworks
 


### PR DESCRIPTION
Hi Erlang Punch team! 👋

This PR adds **erli18n** to the *Translations and Internationalizations* section (it was empty, so this is its first entry).

**erli18n** is a GNU `gettext`-compatible internationalization (i18n) library for Erlang/OTP, written in pure Erlang — OTP 27+, Apache-2.0, published on Hex. It loads standard `.po`/`.pot` catalogs, has a real CLDR `Plural-Forms` evaluator, and exposes the full gettext API (`gettext`/`ngettext`/`pgettext`/`npgettext`).

- Hex: https://hex.pm/packages/erli18n
- Docs: https://hexdocs.pm/erli18n
- Repo: https://github.com/eagle-head/erli18n

I followed the current markdown + html `<details>` model used throughout the list. (Disclosure: I'm the author — erli18n is my first Hex package and a learning project.)

Thanks a lot for maintaining Awesome Erlang! 🙏
